### PR TITLE
Generalized the HasTransform instance to TransformT m

### DIFF
--- a/src/Language/Haskell/GHC/ExactPrint/Transform.hs
+++ b/src/Language/Haskell/GHC/ExactPrint/Transform.hs
@@ -1090,8 +1090,9 @@ modifyValD p ast f = do
 class (Monad m) => (HasTransform m) where
   liftT :: Transform a -> m a
 
-instance HasTransform (TransformT Identity) where
-  liftT = id
+instance Monad m => HasTransform (TransformT m) where
+  liftT (TransformT (RWST t))
+    = TransformT . RWST $ \r s -> return . runIdentity $ t r s
 
 -- ---------------------------------------------------------------------
 


### PR DESCRIPTION
With the old version, you were kinda forced to
always use fully concrete monads and write
your own instance of HasTransform.
This version would allow you to
use `Monad m => TransformT (ComplicatedMonadStack m)`.

Does this seem like a good idea?