### PR TITLE
Include test examples for ghc82

### DIFF
--- a/ghc-exactprint.cabal
+++ b/ghc-exactprint.cabal
@@ -36,6 +36,7 @@ extra-source-files:  ChangeLog
                      tests/examples/ghc710/*.hs
                      tests/examples/ghc710-only/*.hs
                      tests/examples/ghc80/*.hs
+                     tests/examples/ghc82/*.hs
                      tests/examples/transform/*.hs
                      tests/examples/failing/*.hs.bad
                      tests/examples/transform/*.hs.expected


### PR DESCRIPTION
Hi, I noticed an install failure for `ghc-exactprint-0.5.5.0` on nixos due to missing `tests/examples/ghc82` folder (nix executes tests as part of the install by default).  This PR simply includes the `tests/examples/ghc82` folder to the source bundle.

As a temporary workaround, I turned off tests for this package by overriding the installation its installation process.

Thanks!