### PR TITLE
Add support for ghc-8.8.4

### DIFF
--- a/ghc-exactprint.cabal
+++ b/ghc-exactprint.cabal
@@ -43,6 +43,7 @@ tested-with:         GHC == 7.10.3
                    , GHC == 8.8.1
                    , GHC == 8.8.2
                    , GHC == 8.8.3
+                   , GHC == 8.8.4
                    , GHC == 8.10.1
 extra-source-files:  ChangeLog
                      src-ghc710/Language/Haskell/GHC/ExactPrint/*.hs
@@ -123,7 +124,7 @@ library
       build-depends: ghc-boot
   hs-source-dirs:      src
 
-  if impl (ghc > 8.8.3)
+  if impl (ghc > 8.8.4)
       hs-source-dirs: src-ghc810
   else
     if impl (ghc > 8.6.5)
@@ -155,7 +156,7 @@ Test-Suite test
   else
     hs-source-dirs:      tests
 
-  if impl (ghc > 8.8.3)
+  if impl (ghc > 8.8.4)
       hs-source-dirs: src-ghc810
   else
     if impl (ghc > 8.6.5)


### PR DESCRIPTION
* the build with ghc-8.8.4 fails cause it is was using the sources for ghc-8.10.1
* the change could be released as a hackage revision, for all versions supporting ghc-8.8.3, i suppose
* tests are failing in my local windows, but they fail with ghc-8.8.3 so i guess it is a windows issue