### PR TITLE
Sort comments properly, ignoring SrcSpan's file

### DIFF
--- a/src/Language/Haskell/GHC/ExactPrint/Parsers.hs
+++ b/src/Language/Haskell/GHC/ExactPrint/Parsers.hs
@@ -338,10 +338,10 @@ postParseTransform
   :: Either a (GHC.ApiAnns, [Comment], GHC.DynFlags, GHC.ParsedSource)
   -> DeltaOptions
   -> Either a (Anns, GHC.ParsedSource)
-postParseTransform parseRes opts = either Left mkAnns parseRes
+postParseTransform parseRes opts = fmap mkAnns parseRes
   where
     mkAnns (apianns, cs, _, m) =
-      Right (relativiseApiAnnsWithOptions opts cs m apianns, m)
+      (relativiseApiAnnsWithOptions opts cs m apianns, m)
 
 -- | Internal function. Initializes DynFlags value for parsing.
 --

--- a/tests/Test/Common.hs
+++ b/tests/Test/Common.hs
@@ -63,7 +63,7 @@ import System.FilePath
 
 -- import Debug.Trace
 testPrefix :: FilePath
-testPrefix = "tests" </> "examples"
+testPrefix = "." </> "tests" </> "examples"
 
 testList :: String -> [Test] -> Test
 testList s ts = TestLabel s (TestList ts)

--- a/tests/examples/failing/overloadedlabelsrun04.hs.bad
+++ b/tests/examples/failing/overloadedlabelsrun04.hs.bad
@@ -2,17 +2,11 @@
 
 import OverloadedLabelsRun04_A
 
-
-
+-- Who knew that there were so many ways that a line could start with
+-- a # sign in Haskell? None of these are overloaded labels:
 
 
 #!notashellscript
 
 -- But this one is:
--- a # sign in Haskell? None of these are overloaded labels:
-
-
-
-
-
 #foo


### PR DESCRIPTION
Fixes #92. Fixes https://github.com/mpickering/apply-refact/issues/88.

The reason of the behavior described in #92 is that the shebang is converted to a comment whose `SrcSpan` file is "SHEBANG". Comments are sorted on their `SrcSpan`s; `SrcSpan`s are compared first by file name, and `"./test/Foo.hs" < "SHEBANG" < "test/Foo.hs"`.

Now it ignores the file name when sorting comments.