### PR TITLE
Wip ghc 9.3

### DIFF
--- a/src/Language/Haskell/GHC/ExactPrint/Dump.hs
+++ b/src/Language/Haskell/GHC/ExactPrint/Dump.hs
@@ -59,7 +59,6 @@ showAstData bs ba a0 = blankLine $$ showAstData' a0
               `extQ` annotationAddEpAnn
               `extQ` annotationGrhsAnn
               `extQ` annotationEpAnnHsCase
-              `extQ` annotationEpAnnHsLet
               `extQ` annotationAnnList
               `extQ` annotationEpAnnImportDecl
               `extQ` annotationAnnParen
@@ -239,9 +238,6 @@ showAstData bs ba a0 = blankLine $$ showAstData' a0
 
             annotationEpAnnHsCase :: EpAnn EpAnnHsCase -> SDoc
             annotationEpAnnHsCase = annotation' (text "EpAnn EpAnnHsCase")
-
-            annotationEpAnnHsLet :: EpAnn AnnsLet -> SDoc
-            annotationEpAnnHsLet = annotation' (text "EpAnn AnnsLet")
 
             annotationAnnList :: EpAnn AnnList -> SDoc
             annotationAnnList = annotation' (text "EpAnn AnnList")

--- a/src/Language/Haskell/GHC/ExactPrint/Orphans.hs
+++ b/src/Language/Haskell/GHC/ExactPrint/Orphans.hs
@@ -52,9 +52,6 @@ instance Default EpAnnHsCase where
 instance Default AnnsIf where
   def = AnnsIf def def def def def
 
-instance Default AnnsLet where
-  def = AnnsLet def def
-
 instance Default AnnProjection where
   def = AnnProjection def def
 
@@ -71,7 +68,7 @@ instance Default AnnKeywordId where
   def = Annlarrowtail  {- gotta pick one -}
 
 instance Default TrailingAnn where
-  def = AddLollyAnnU {-gotta pick one -} def
+  def = AddSemiAnn {-gotta pick one -} def
 
 instance Default AnnContext where
   def = AnnContext Nothing [] []

--- a/src/Language/Haskell/GHC/ExactPrint/Utils.hs
+++ b/src/Language/Haskell/GHC/ExactPrint/Utils.hs
@@ -32,6 +32,7 @@ import GHC.Types.Name.Reader
 import GHC.Types.SrcLoc
 import GHC.Data.FastString
 import GHC.Utils.Outputable ( showPprUnsafe )
+import qualified GHC.Data.Strict as Strict
 
 import Data.List (sortBy, elemIndex)
 
@@ -357,26 +358,16 @@ trailingAnnToAddEpAnn :: TrailingAnn -> AddEpAnn
 trailingAnnToAddEpAnn (AddSemiAnn ss)    = AddEpAnn AnnSemi ss
 trailingAnnToAddEpAnn (AddCommaAnn ss)   = AddEpAnn AnnComma ss
 trailingAnnToAddEpAnn (AddVbarAnn ss)    = AddEpAnn AnnVbar ss
-trailingAnnToAddEpAnn (AddRarrowAnn ss)  = AddEpAnn AnnRarrow ss
-trailingAnnToAddEpAnn (AddRarrowAnnU ss) = AddEpAnn AnnRarrowU ss
-trailingAnnToAddEpAnn (AddLollyAnnU ss)  = AddEpAnn AnnLollyU ss
 
 trailingAnnLoc :: TrailingAnn -> EpaLocation
 trailingAnnLoc (AddSemiAnn ss)    = ss
 trailingAnnLoc (AddCommaAnn ss)   = ss
 trailingAnnLoc (AddVbarAnn ss)    = ss
-trailingAnnLoc (AddRarrowAnn ss)  = ss
-trailingAnnLoc (AddRarrowAnnU ss) = ss
-trailingAnnLoc (AddLollyAnnU ss)  = ss
 
 setTrailingAnnLoc :: TrailingAnn -> EpaLocation -> TrailingAnn
 setTrailingAnnLoc (AddSemiAnn _)    ss = (AddSemiAnn ss)
 setTrailingAnnLoc (AddCommaAnn _)   ss = (AddCommaAnn ss)
 setTrailingAnnLoc (AddVbarAnn _)    ss = (AddVbarAnn ss)
-setTrailingAnnLoc (AddRarrowAnn _)  ss = (AddRarrowAnn ss)
-setTrailingAnnLoc (AddRarrowAnnU _) ss = (AddRarrowAnnU ss)
-setTrailingAnnLoc (AddLollyAnnU _)  ss = (AddLollyAnnU ss)
-
 
 addEpAnnLoc :: AddEpAnn -> EpaLocation
 addEpAnnLoc (AddEpAnn _ l) = l
@@ -415,16 +406,16 @@ To be absolutely sure, we make the delta versions use -ve values.
 
 hackSrcSpanToAnchor :: SrcSpan -> Anchor
 hackSrcSpanToAnchor (UnhelpfulSpan s) = error $ "hackSrcSpanToAnchor : UnhelpfulSpan:" ++ show s
-hackSrcSpanToAnchor (RealSrcSpan r Nothing) = Anchor r UnchangedAnchor
-hackSrcSpanToAnchor (RealSrcSpan r (Just (BufSpan (BufPos s) (BufPos e))))
+hackSrcSpanToAnchor (RealSrcSpan r Strict.Nothing) = Anchor r UnchangedAnchor
+hackSrcSpanToAnchor (RealSrcSpan r (Strict.Just (BufSpan (BufPos s) (BufPos e))))
   = if s <= 0 && e <= 0
     then Anchor r (MovedAnchor (deltaPos (-s) (-e)))
     else Anchor r UnchangedAnchor
 
 hackAnchorToSrcSpan :: Anchor -> SrcSpan
-hackAnchorToSrcSpan (Anchor r UnchangedAnchor) = RealSrcSpan r Nothing
+hackAnchorToSrcSpan (Anchor r UnchangedAnchor) = RealSrcSpan r Strict.Nothing
 hackAnchorToSrcSpan (Anchor r (MovedAnchor dp))
-  = RealSrcSpan r (Just (BufSpan (BufPos s) (BufPos e)))
+  = RealSrcSpan r (Strict.Just (BufSpan (BufPos s) (BufPos e)))
   where
     s = - (getDeltaLine dp)
     e = - (deltaColumn dp)


### PR DESCRIPTION
First Draft of changes for 9.3 (I've deliberately left out the `Language/Haskell/ExactPrint/ExactPrint.hs` module for now.

Do you want <9.3 compatibility? 