### PR TITLE
prepend decl tests

### DIFF
--- a/tests/Test/Transform.hs
+++ b/tests/Test/Transform.hs
@@ -4,6 +4,7 @@
 
  -- Many of the tests match on a specific expected value,the other patterns should trigger a fail
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+{-# LANGUAGE LambdaCase #-}
 module Test.Transform where
 
 import Language.Haskell.GHC.ExactPrint
@@ -292,6 +293,7 @@ transformHighLevelTests libdir =
   , mkTestModChange libdir addLocaLDecl4  "AddLocalDecl4.hs"
   , mkTestModChange libdir addLocaLDecl5  "AddLocalDecl5.hs"
   , mkTestModChange libdir addLocaLDecl6  "AddLocalDecl6.hs"
+  , mkTestModChange libdir addLocaLDecl7  "AddLocalDecl7.hs"
 
   , mkTestModChange libdir rmDecl1 "RmDecl1.hs"
   , mkTestModChange libdir rmDecl2 "RmDecl2.hs"
@@ -438,6 +440,60 @@ addLocaLDecl6 libdir lp = do
   (lp',_,_w) <- runTransformT doAddLocal
   debugM $ "log:[\n" ++ intercalate "\n" _w ++ "]log end\n"
   return lp'
+
+addLocaLDecl7 :: Changer
+addLocaLDecl7 libdir top = do
+  Right (L ld (ValD _ decl)) <- withDynFlags libdir (\df -> parseDecl df "decl" "nn = 2")
+  let decl' = setEntryDP (L ld decl) (DifferentLine 1 5)
+      doAddLocal = do
+        let lp = makeDeltaAst top
+        ds <- balanceCommentsList =<< hsDecls lp
+        ds' <- flip mapM ds $ \d -> do
+          (d',_) <- modifyValD (getLocA d) d $ \_m ds -> do
+            pure (prependDecl (wrapDecl decl') ds, Nothing)
+          pure d'
+        replaceDecls lp ds'
+  (lp',_,w) <- runTransformT doAddLocal
+  debugM $ "addLocaLDecl7:" ++ intercalate "\n" w
+  return lp'
+
+prependDecl :: LHsDecl GhcPs -> [LHsDecl GhcPs] -> [LHsDecl GhcPs]
+prependDecl ldecl = \case
+  [] -> [setEntryDP ldecl (DifferentLine 1 2)]
+  ld1:lds -> ldecl':ld1'':lds
+    where
+      (ancOp, ld1'') = case ld1 of
+        (L (SrcSpanAnn (EpAnn _ _ (EpaComments _)) _) _) ->
+          error "Unexpected unbalanced comments"
+        (L (SrcSpanAnn (EpAnn d1Anc d1Ann (EpaCommentsBalanced (L (Anchor c1Rss cAnc) c1:restCs) d1AfterCs)) ss) d1) ->
+          -- NOTE cannot use setEntryDP to simply assign `DL 1 0` here because when there is a prior comment, the
+          --      DeltaPos on the declaration is absolute instead of relative, and so we must manually update the
+          --      DeltaPos to be relative (since there is about to be a prior declaration).
+          let ld1' = L
+                (SrcSpanAnn
+                  (EpAnn
+                    (setAnchorDp d1Anc $ DifferentLine 1 0)
+                    d1Ann
+                    (EpaCommentsBalanced (L (Anchor c1Rss $ MovedAnchor $ DifferentLine 1 0) c1:restCs) d1AfterCs))
+                  ss)
+                d1
+          in (cAnc, ld1')
+        (L (SrcSpanAnn (EpAnn (Anchor d1Rss d1AncOp) d1Ann epaCs@(EpaCommentsBalanced [] _)) ss) d1) ->
+          let ld1' = L (SrcSpanAnn (EpAnn (Anchor d1Rss $ MovedAnchor $ DifferentLine 1 0) d1Ann epaCs) ss) d1
+          in (d1AncOp, ld1')
+        L (SrcSpanAnn EpAnnNotUsed _) _ -> error "Unexpected EpAnnNotUsed"
+      ldecl' = setEntryDP ldecl (getAnchorOpDp ancOp)
+
+getAnchorDp :: Anchor -> DeltaPos
+getAnchorDp (Anchor _ (MovedAnchor dp)) = dp
+getAnchorDp (Anchor _ UnchangedAnchor) = error "Unexpected UnchangedAnchor"
+
+setAnchorDp :: Anchor -> DeltaPos -> Anchor
+setAnchorDp (Anchor rss _) dp = Anchor rss (MovedAnchor dp)
+
+getAnchorOpDp :: AnchorOperation -> DeltaPos
+getAnchorOpDp (MovedAnchor dp) = dp
+getAnchorOpDp UnchangedAnchor = error "Unexpected UnchangedAnchor"
 
 -- ---------------------------------------------------------------------
 

--- a/tests/examples/transform/AddLocalDecl7.hs
+++ b/tests/examples/transform/AddLocalDecl7.hs
@@ -1,0 +1,20 @@
+module AddLocalDecl7 where
+
+d1 = 1
+  where -- c1
+        w1 = 1
+
+d2 = 1
+  where w2 = 1
+
+d3 = 1
+  where
+
+d4 = 1
+
+d5 = 1
+  where -- c5
+
+d6 = 1 where
+
+d7 = 1 where -- c7

--- a/tests/examples/transform/AddLocalDecl7.hs.expected
+++ b/tests/examples/transform/AddLocalDecl7.hs.expected
@@ -1,0 +1,28 @@
+module AddLocalDecl7 where
+
+d1 = 1
+  where nn = 2
+        -- c1
+        w1 = 1
+
+d2 = 1
+  where nn = 2
+        w2 = 1
+
+d3 = 1
+  where
+  nn = 2
+
+d4 = 1
+  where
+    nn = 2
+
+d5 = 1
+  where
+  nn = 2 -- c5
+
+d6 = 1 where
+  nn = 2
+
+d7 = 1 where
+  nn = 2 -- c7


### PR DESCRIPTION
Hey @alanz :) 

I tried out adding something that I would _want_ (not need) for HLS plugins: prepending a declaration onto a list of declarations. I also wanted to try this out to see if I'm being sane in general when using the API.

Hopefully, my using the API can be helpful to you as feedback - so please do ask lots of questions :)

Some things I bumped into:
 - I couldn't see a way to run a single test: I instead had to run the entire test suite every time
 - There appears to be no formatter configured on the repo. It would help me produce nicer code and reduce conflicts long-term
 - The repo has a lot of large files - would it be okay to chop them up?