### PR TITLE
Reinstate TransformT deriving from MonadTrans

### DIFF
--- a/src/Language/Haskell/GHC/ExactPrint/Transform.hs
+++ b/src/Language/Haskell/GHC/ExactPrint/Transform.hs
@@ -119,6 +119,7 @@ newtype TransformT m a = TransformT { unTransformT :: RWST () [String] Int m a }
                          ,MonadReader ()
                          ,MonadWriter [String]
                          ,MonadState Int
+                         ,MonadTrans
                          )
 
 instance Fail.MonadFail m => Fail.MonadFail (TransformT m) where


### PR DESCRIPTION
This PR fixes #132 by making TransformT derive from MonadTrans again.
It was removed in #124 

It's probably a good idea to have a test for this to ensure that the instance `MonadTrans TransformT` always exists. How would I go about that?