### PR TITLE
Establish a layout offset for class and instance bodies

### DIFF
--- a/src/Language/Haskell/GHC/ExactPrint/ExactPrint.hs
+++ b/src/Language/Haskell/GHC/ExactPrint/ExactPrint.hs
@@ -2217,7 +2217,7 @@ instance ExactPrint (ClsInstDecl GhcPs) where
           (mbWarn', i', w', mbOverlap', inst_ty') <- top_matter
           oc' <- markEpToken oc
           semis' <- mapM markEpToken semis
-          (sortKey', ds) <- withSortKey sortKey
+          (sortKey', ds) <- setLayoutBoth $ withSortKey sortKey
                                [(ClsAtTag, prepareListAnnotationA ats),
                                 (ClsAtdTag, prepareListAnnotationF adts),
                                 (ClsMethodTag, prepareListAnnotationA binds),
@@ -3606,7 +3606,7 @@ instance ExactPrint (TyClDecl GhcPs) where
           (c', w', vb', fds', lclas', tyvars',context') <- top_matter
           oc' <- markEpToken oc
           semis' <- mapM markEpToken semis
-          (sortKey', ds) <- withSortKey sortKey
+          (sortKey', ds) <- setLayoutBoth $ withSortKey sortKey
                                [(ClsSigTag, prepareListAnnotationA sigs),
                                 (ClsMethodTag, prepareListAnnotationA methods),
                                 (ClsAtTag, prepareListAnnotationA ats),

--- a/tests/Test/Transform.hs
+++ b/tests/Test/Transform.hs
@@ -21,6 +21,7 @@ import Data.Generics as SYB
 
 import System.FilePath
 import Data.List
+import Data.List.NonEmpty (NonEmpty ((:|)))
 
 import Test.Common
 
@@ -62,6 +63,7 @@ transformLowLevelTests libdir = [
   , mkTestModChange libdir changeLocalDecls2 "LocalDecls2.hs"
   , mkTestModChange libdir changeWhereIn3a   "WhereIn3a.hs"
   , mkTestModChange libdir changeWhereIn3b   "WhereIn3b.hs"
+  , mkTestModChange libdir changeInstanceGraft "InstanceGraft.hs"
 --  , mkTestModChange changeCifToCase  "C.hs"          "C"
   ]
 
@@ -99,6 +101,26 @@ changeWhereIn3a _libdir (L l p) = do
   debugM $ "changeWhereIn3a:de1:" ++ showAst de1
   let p2 = p { hsmodDecls = decls}
   return (L l p2)
+
+-- ---------------------------------------------------------------------
+
+-- | A delta-anchored expression grafted into a class or instance method
+-- must indent its continuation lines relative to the method declarations
+-- layout column.
+changeInstanceGraft :: Changer
+changeInstanceGraft _libdir top = do
+  let lp = makeDeltaAst top
+      grab :: HsBind GhcPs -> [LHsExpr GhcPs]
+      grab FunBind{ fun_id = L _ n
+                  , fun_matches = MG{mg_alts = L _ [L _ Match{m_grhss = GRHSs _ (L _ (GRHS _ _ e) :| []) _}]}}
+        | occNameString (rdrNameOcc n) == "combine" = [e]
+      grab _ = []
+      [body] = everything (++) ([] `mkQ` grab) lp
+      replace :: LHsExpr GhcPs -> LHsExpr GhcPs
+      replace (L _ (HsVar _ (L _ n)))
+        | occNameString (rdrNameOcc n) == "todo" = setEntryDP body (SameLine 1)
+      replace x = x
+  return (everywhere (mkT replace) lp)
 
 -- ---------------------------------------------------------------------
 

--- a/tests/examples/transform/InstanceGraft.hs
+++ b/tests/examples/transform/InstanceGraft.hs
@@ -1,0 +1,12 @@
+module InstanceGraft where
+
+combine :: Int -> Int -> Int
+combine a b = a
+  + b
+
+class C t where
+  go :: t -> Int
+  go n = todo
+
+instance C Int where
+  go n = todo

--- a/tests/examples/transform/InstanceGraft.hs.expected
+++ b/tests/examples/transform/InstanceGraft.hs.expected
@@ -1,0 +1,14 @@
+module InstanceGraft where
+
+combine :: Int -> Int -> Int
+combine a b = a
+  + b
+
+class C t where
+  go :: t -> Int
+  go n = a
+    + b
+
+instance C Int where
+  go n = a
+    + b


### PR DESCRIPTION
I believe I have found a bug in ghc-exactprint while using it to graft an expression. A minimal reproduction of what I am trying to do can be found in `changeInstanceGraft` and serves as a regression test for this issue.

The problem is that the continuation line from the grafted expression does not seem to notice the required indentation of class and instance declarations. The patch here is to enclose the declarations with `setLayoutBoth` which introduces the required indentation.

This seems like the correct thing to do, and it does resolve the test case, but I would appreciate a review from someone more familiar with the codebase.

Kindly note that this patch was created with help from Claude Fable 5.